### PR TITLE
SVCB overhaul

### DIFF
--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -75,6 +75,10 @@ informative:
       name: Elizabeth Baier
     target: https://www.digicert.com/blog/evolution-of-ssl
     date: 2015-02-02
+  SUIB:
+    title: "Router and IoT Vulnerabilities: Insecure by Design"
+    target: https://manysecured.net/wp-content/uploads/2022/09/ManySecured-SUIB-White-Paper.pdf
+    date: 2021
 
 --- abstract
 
@@ -639,6 +643,12 @@ can provide details already that would otherwise only be discovered later throug
 For when those details are provided in the shape of Service Binding Parameters,
 this section describes their interpretation in the context of CoAP transport indication.
 
+The subsections in this section are arranged to describe a consistent sequential full picture.
+The capabilities of this big picture are not exercised by any application known at the time of draft publication.
+It is instead backed by many small-scope use cases
+(such as bootstrapping issues of proxy-link based CoAP scheme unification, {{?I-D.lenders-core-dnr}}, {{?I-D.amsuess-t2trg-onion-coap}} and also applications outside CoAP such as {{SUIB}})
+and presents a unified solution framework.
+
 ## Discovering transport indication details from name resolution {#svcb-discovery}
 
 When a host finds a CoAP transport from a URI
@@ -654,6 +664,18 @@ and thus enables the use of SVCB records.
 This path is chosen over the creation of a new SVCB RR pair "COAP" / "COAPS"
 because it is considered unlikely that DNS implementations would update their code bases to apply SVCB behavior;
 this assumption will be revisited before registration.
+
+These can be used during the resolution of URIs using the "coap" or "coaps" schemes, respectively.
+No such labels are registered for other CoAP schemes that have been registered,
+as it is expected that applications that use them will prefer leaving the more detailed transport choice to the parameters.
+The "coaps" scheme comes with the expectation of using a secured transport.
+While discovered parameters can override this, components and applications
+MUST NOT select a transport and security mechanism combination with a reduced security level.
+
+\[ There is no formal description of what the requirements following "coaps" really are.
+Would it make sense to only register "coap" here, unifying the scheme space even further,
+given that any applications needs to describe its security requirements anyway,
+and can just as well apply them to "coap"? \]
 
 Some SVCB parameters have defaults; for those new services, these are:
 * port: 5683 for `_coap`, 5684 for `_coaps`

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -896,9 +896,12 @@ for example by using separate connection and cache pools.
 
 ## Expressing Service Parameters as literals {#svcblit}
 
-TBD
+A method for expressing Service Parameters in URIs that do not use registered names
+is described in {{newlit}}.
 
-### Examples
+Among other things,
+that mechanism allows encoding the full information obtained during service discovery in a URI
+instead of just the one choice taken.
 
 # Guidance to upcoming transports {#upcomingtransports}
 

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -719,10 +719,10 @@ and independently of whether they apply to the `_coap` / `_coaps` service or ano
 
   \[ It is left for review by SVCB experts whether these are a separate parameter space or we should just take ALPNs for them, like eg. h2c does. \]
 
-* `cred`: This is a new parameter defined in this document, and describes credentials usable to authenticate the server.
+* `edhoc`: This is a new parameter defined in this document, and describes that EDHOC can be used with the server, and which credentials can authenticate the server.
 
-  The `cred` parameter's value is a CBOR sequence of COSE Header maps as defined in {{!RFC9052}}.
-  If the parameter is present, it indicates that a COSE based security layer such as EDHOC can be used on the transport,
+  The `edhoc-cred` parameter's value is a CBOR sequence of COSE Header maps as defined in {{!RFC9052}}.
+  If the parameter is present, it indicates that EDHOC {{!RFC9528}} can be used on the transport,
   and that the server can be authenticated by any credential expressed in the sequence.
   This is similar to the TLSA records specified in {{?RFC6698}}.
 
@@ -735,21 +735,13 @@ and independently of whether they apply to the `_coap` / `_coaps` service or ano
   and that public key does not need to be sent during the EDHOC exchange.
   Alternatively, a header map with an `x5t` identifies the end entity certificate the server presents by a thumbprint (hash).
 
-  It is up to the application to define requirements for the provenance of the `cred` parameter,
+  It is up to the application to define requirements for the provenance of the `edhoc-cred` parameter,
   whether it needs to be provided through secure mechanism,
   or whether the server is strictly required to present that credential.
 
   This is unlike TLSA, which needs to be transported through DNSSEC,
-  because a `cred` parameter may be sent using other means than DNS
+  because a `edhoc-cred` parameter may be sent using other means than DNS
   (for example in DHCPv6 responses or Router Advertisements).
-
-  \[
-  The current phrasing of this is rather general toward COSE,
-  but we only have two security mechanisms based on it for CoAP,
-  and only one of those is asymmetric enough to be practical.
-  Should we try to stay generic, or just call this "edhoc" and be done with it?
-  (Applications where a server is identified by OSCORE kid are very limited in that the OSCORE context needs to be pre-established, and the ).
-  \]
 
 * `edhoc-info`: This is a new parameter defined in this document, describing how EDHOC can be used on the server.
 
@@ -800,7 +792,7 @@ It therefore updates its DNS record like this:
 ```
 _coap.host.example.net 600 IN SVCB 1 publicudp.host.example.net       \
                        port=5678                                      \
-                       cred={14:{... /KCCS containing its public key/}}
+                       edhoc-cred={14:{... /KCCS with its public key/}}
 ```
 
 When a client starts using `coap://host.example.net/interactive`,
@@ -808,7 +800,7 @@ it looks up that record and verifies it using DNSSEC.
 It then proceeds to send EDHOC requests over CoAP to 1.2.3.4 port 5678,
 setting the Uri-Host option to "host.example.net".
 
-The client could also have initiated an EDHOC session if no cred parameter had been present,
+The client could also have initiated an EDHOC session if no edhoc-cred parameter had been present,
 but then,
 it would have required that the server present some credential that could be verified through the Web PKI,
 for example an x5chain containing a Let's Encrypt certificate.

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -632,9 +632,9 @@ If the forward proxy was only used out of necessity
 (e.g., to access a resource whose indicated transport not supported by the client)
 it can be practical for the client to use the advertised proxy instead.
 
-# Transport indication from other sources: Service Binding Parameters
+# Transport indication from non-link sources: Service Binding Parameters
 
-Discovery mechanisms that exist in DNS {{?RFC9460}}, DHCP or Router Advertisements {{?RFC9463}}
+Discovery mechanisms that exist in DNS {{?RFC9460}}, DHCP, Router Advertisements {{?RFC9463}} or other mechanisms
 can provide details already that would otherwise only be discovered later through proxy links.
 For when those details are provided in the shape of Service Binding Parameters,
 this section describes their interpretation in the context of CoAP transport indication.
@@ -648,9 +648,9 @@ For example, if it supports CoAP-over-UDP and IPv6,
 it requests AAAA records through DNS and look them up in a host file.
 
 This document extends this and registers the `_coap` and `_coaps` attrleaf labels
-in {{iana-underscored}},
-using the pattern described as described in {{Section 10.4.5 of RFC9460}}
-and thus enabling the use of SVCB records.
+in {{iana-underscored}}
+using the pattern described as described in {{Section 10.4.5 of RFC9460}},
+and thus enables the use of SVCB records.
 This path is chosen over the creation of a new SVCB RR pair "COAP" / "COAPS"
 because it is considered unlikely that DNS implementations would update their code bases to apply SVCB behavior;
 this assumption will be revisited before registration.

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -750,6 +750,28 @@ and independently of whether they apply to the `_coap` / `_coaps` service or ano
 
   It is optional to provide and optional to process, but can help speed up the establishment of a security context.
 
+* `oauth-hints`: This is a new parameter defined in this document,
+  describing how ACE-OAuth {{?RFC9200}} can be used with this service.
+
+  Its value is a CBOR map containing AS Request Creation Hints as described in {{Section 5.3 of RFC9200}}.
+  While an empty map can be useful (hinting that the client should use its configured ACE-OAuth setup),
+  typical useful keys are
+  1 (AS, indicating the URI of the Authorization Server),
+  5 (audience, indicating the name under which the service is known to the Authorization Server),
+  and 9 (scope, when discovering a particular service rather than just getting transport information for a host).
+  That data is using the same shape the server might use when responding to an attempt at an unencrypted connection,
+  and can not only speed up the discovery of the right AS,
+  but can also protect that information (eg. when DNSSEC is used),
+  and avoids the need for an unprotected first request.
+
+  It is up to the application to define requirements for the use of such data.
+  For example,
+  it may require that the audience matches the requested host name,
+  or may require that the scope matches the kind of service being discovered.
+
+  When expressed in text format, e.g. in DNS zone files,
+  the CBOR diagnostic notation {{?I-D.ietf-cbor-edn-literals}} can be used.
+
 ### Examples of using name resolution discovery and parameters
 
 #### Generic client discovering transport options

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -150,8 +150,11 @@ but also by the authority component.
 The transports and resolution mechanisms currently specified
 make little use of this possibility,
 mainly because the most prominent resolution mechanism (SVCB records) has not been avaialble when {{?RFC8323}} was published
-(see also {{althist}}),
-end because it can not be expressed in IP literals (see {{newlit}}).
+and because it can not be expressed in IP literals.
+The provisions of this document
+enable this opportunistically for registered names
+({{svcb-discovery}})
+and for literals using the mechanism in {{newlit}}.
 
 When the resolution mechanism used for a registered name authority component yields multiple addresses,
 all of those are possible ways to interact with the resource.
@@ -688,6 +691,8 @@ but MAY attempt it opportunistically in order to obtain a usable transport
 Applications built on CoAP MAY require clients to perform this kind of discovery.
 Adding such a requirement is particularly useful if the application frequently advertises URIs with a scheme that defaults to a transport which its clients may not support,
 or when the application makes use of functionality afforded by {{?RFC9460}} such as apex domain redirection.
+(Had the SVCB specification predated the first new CoAP transports,
+that mechanism might have been used in the first place instead of additional schemes).
 
 The effects on a client of seeing SVCB parameters are similar
 to those of seeing a "has-proxy" link from the origin to the URI built using {#svcblit}.
@@ -916,6 +921,10 @@ is described in {{newlit}}.
 Among other things,
 that mechanism allows encoding the full information obtained during service discovery in a URI
 instead of just the one choice taken.
+It is also required if different CoAP transports are using the same scheme
+(as is recommended in {{upcomingtransports}})
+with IP address literals in URIs,
+for which unlike for resolved names no service parameters are available.
 
 # Guidance to upcoming transports {#upcomingtransports}
 
@@ -1196,8 +1205,7 @@ DNS Service Binding resource records (SVCB RRs)
 described in {{?RFC9460}} can carry many of the details otherwise negotiated using the proxy relations.
 In HTTP, they can be used in a way similar to Alt-Svc headers.
 
-SVCB records were not specified when CoAP was specified for TCP,
-but could have been (see {{althist}}).
+SVCB records were not specified when CoAP was specified for TCP.
 
 If at any point SVCB records for CoAP are defined,
 name resolution produces a set of transport details that can be used immediately
@@ -1315,53 +1323,6 @@ Otherwise, it places the label in its critical form, either empty or containing 
 The client may then decide to discontinue using the proxy,
 or to use more extensive padding options to sidestep the attack.
 Both the client and the server may alert their administrators of a possible traffic misdirection.
-
-# Alternative History: What if SVCB had been around before CoAP over TCP? {#althist}
-
-This appendix explores a hypothetical scenario in which Service Binding (SVCB, {{?RFC9460}}) was around and supported before the controversial decision to establish the "coap+tcp" scheme.
-It serves to provide a fresh perspective of what parts are logically necessary,
-and to ease the exploration of how it may be used in the future.
-
-## Hypothetical retrospecification
-
-CoAP is specified for several transports:
-CoAP over UDP, over DTLS, over TCP, over TLS and over (secure or insecure) WebSockets.
-URIs of all these are expressed using the "coap" or "coaps" scheme,
-depending on whether a (D)TLS connection is to be used.
-\[ It is currently unclear whether the two schemes should also be unified; the rest of the text is left intentionally vague on that distinction. \]
-
-Any server providing CoAP services
-announces not only its address
-but also its SVCB Service Parameters,
-including at least one of `alpn` and `coaptransport`.
-
-For example, a host serving "coap://sensor.example.com" and "coaps://sensor.example.com"
-might have these records:
-
-```
-_coap.sensor.example.com IN SVCB 1 . alpn=coap,co coaptransport=tcp,udp port=61616
-sensor.example.com IN AAAA 2001:db8::1
-```
-
-A client connecting to the server loops up the name's service parameters using its system's discovery mechanisms.
-
-For example, if DNS is used, it obtains SVCB records for \_coap.sensor.example.com,
-and receives the corresponding AAAA record either immediately from an SVCB aware resolver
-or through a second query.
-It learns that the service is available through CoAP-over-DTLS (ALPN "co"), CoAP-over-TLS (ALPN "coap"),
-or through unencrypted TCP or UDP, and that port 61616 needs to be used in all cases.
-
-If the server and the client do not have a transport in common,
-or if one of them supports only IPv4 and the other only IPv6,
-no exchange is possible;
-the client may resort to using a proxy.
-
-## Shortcomings
-
-While the mechanism above would have unified the CoAP transports under a pair of schemes,
-it would have rendered the use of IP literals impossible:
-The URI `coap://[2001:db8::1]` would be ambiguous as to whether CoAP-over-UDP or CoAP-over-TCP should be used.
-{{newlit}} provides a solution for this issue.
 
 # Literals beyond IP addresses {#newlit}
 

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -1410,7 +1410,11 @@ Initial component types are:
   a client MUST establish a secure connection,
   and MUST fail the connection if the TLSA record's requirements are not met.
 
-* "s": Service Parameters {{?RFC9460}}).
+* "edhoc-cred", "edhoc-info", "oauth-info": SvcbParams in base32 encoding of their wire format.
+
+* "coaptransport": SvcbParam in its text encoding.
+
+* "s": Other Service Parameters that do not have an explicit component type.
   SvcbParams in base32 encoding of their wire format.
 
   TBD: There is likely a transformation of the parameters' presentation format that is compatible with the requirements of the authority component,
@@ -1472,12 +1476,9 @@ they serve to explore the possible alternatives.
   The "mail.-." part is provided to the server as part of the Host header,
   and can be used for name based virtual hosting.
 
-* coap://s.mnxqaaqaafswiacpueekcaneaebcaajblaqlxq2jmbjg5jgtf2kazljkenaurxo.--.cc6i2ckx3zowjgyrai3ouj4bclaqekgpck4rwwkqm4ibd6cjr6hzynst27wte7t.--.paccgcetcr5k7wa4q.6.2001-db8--1.service.arpa/ -- The server is reachable using CoAP over TCP with EDHOC security at 2001:db8::1, and the service is identifiable by the use of a KCCS credential..
+* coap://coaptransport.tcp.edhoc-cred.ueekcandaeasabbblaqlxq2jmbjg5jgtf2kazljkenaurxocc6i2ckx3zowjgyr.--.ai3ouj4a.6.2001-db8--1.service.arpa/ -- The server is reachable using CoAP over TCP with EDHOC security at 2001:db8::1, and the service is identifiable by the use of a KCCS credential describing an X25519 public key.
 
-  The sequence of base32 encoded data in the `s` parameter means (modulo encoding errors: the SVCB parameter encoding was done by hand, assuming some allocated code points):
-
-  * coaptransport=tcp
-  * edhoc-cred={14: {8: {1: {1: 2, -1: 1, -2: h'bbc34960526ea4d32e940cad2a234148ddc21791a12afbcbac93622046dd44f0', -3: h'4519e257236b2a0ce2023f0931f1f386ca7afda64fcde0108c224c51eabf6072'}}}}
+* coap://edhoc-cred.ueekcandaeasabbblaqlxq2jmbjg5jgtf2kazljkenaurxocc6i2ckx3zowjgyr.--.ai3ouj4a.service.arpa/ -- The same server without any discoverability hints; it is up to the client to discover a (possibly short-lived) connection opportunities to the server identified by that key.
 
 # Acknowledgements
 

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -642,7 +642,7 @@ it is recommended to use the "coap" scheme
 
 If the transport's identifiers are IP based and have identifiers typically resolved through DNS,
 authors of new transports are encouraged to specify Service Binding records ({{?RFC9460}}) for CoAP,
-e.g., using a `coaptransport`, (possibly taking inspiration from {{althist}}),
+e.g., using an `alpn` or `coaptransport` parameter.
 and if IP literals are relevant to the transport, to follow up on {{newlit}}.
 
 If the transport's native identifiers are compatible with the structure of the authority component of a URI,

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -815,18 +815,19 @@ it would have required that the server present some credential that could be ver
 for example an x5chain containing a Let's Encrypt certificate.
 
 
-## Expressing Service Parameters as literals {#svcblit}
-
-TBD
-
-### Examples
-
 ## Producing a URI from a discovered service {#svcb2uri}
 
 If a service's discovery process does not produce a URI but an address, host name and/or Service Binding Parameters,
 those can be converted to a CoAP URI,
 for which transport hints are already encoded in the parameters the URI is constructed from.
 An example of this is DNS server discovery {{?I-D.lenders-core-dnr}}.
+
+TBD
+
+### Examples
+
+
+## Expressing Service Parameters as literals {#svcblit}
 
 TBD
 

--- a/draft-ietf-core-transport-indication.md
+++ b/draft-ietf-core-transport-indication.md
@@ -1472,7 +1472,12 @@ they serve to explore the possible alternatives.
   The "mail.-." part is provided to the server as part of the Host header,
   and can be used for name based virtual hosting.
 
-* coap://s.coaptransfer_tcp_coapsecurity_edhoc.6.2001-db8--1.service.arpa/ -- The server is reachable using CoAP over TCP with EDHOC security at 2001:db8::1. (The SVCB parameters are experimental values from {{?I-D.lenders-core-dnr}}).
+* coap://s.mnxqaaqaafswiacpueekcaneaebcaajblaqlxq2jmbjg5jgtf2kazljkenaurxo.--.cc6i2ckx3zowjgyrai3ouj4bclaqekgpck4rwwkqm4ibd6cjr6hzynst27wte7t.--.paccgcetcr5k7wa4q.6.2001-db8--1.service.arpa/ -- The server is reachable using CoAP over TCP with EDHOC security at 2001:db8::1, and the service is identifiable by the use of a KCCS credential..
+
+  The sequence of base32 encoded data in the `s` parameter means (modulo encoding errors: the SVCB parameter encoding was done by hand, assuming some allocated code points):
+
+  * coaptransport=tcp
+  * edhoc-cred={14: {8: {1: {1: 2, -1: 1, -2: h'bbc34960526ea4d32e940cad2a234148ddc21791a12afbcbac93622046dd44f0', -3: h'4519e257236b2a0ce2023f0931f1f386ca7afda64fcde0108c224c51eabf6072'}}}}
 
 # Acknowledgements
 


### PR DESCRIPTION
This moves <del>(incomplete: will move)</del> speculative content into just registering in the relevant registries (without, of course, retroactively making CoAP-over-TCP work that way automatically), and will also move content that was dropped in https://github.com/anr-bmbf-pivot/draft-lenders-core-dnr/pull/6 in here.